### PR TITLE
GitHub Packages の Container Registry へデプロイするコースを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ GitHub Learning Lab での演習が終わったら、Microsoft Learn に戻り�
 デプロイしたい先にしたがって、リンク先にお進みください。
 
   - [Microsoft Azure の Web App へデプロイする](./continuous-deployment/deploy-to-azure-web-app.md)
-  - GitHub Packages の Container Registry にデプロイする
+  - [GitHub Packages の Container Registry にデプロイする](./continuous-deployment/push-container-image-to-github-packages.md)
 
 ## Congraturations 🎉
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [2. Node.js 製ウェブアプリで、継続的インテグレーション (CI) を行う](#2-nodejs-製ウェブアプリで継続的インテグレーション-ci-を行う)
 - [3. Node.js 製ウェブアプリで、継続的デプロイ (CD) を行う](#3-nodejs-製ウェブアプリで継続的デプロイ-cd-を行う)
   - Microsoft Azure の Web App へデプロイする
-  - GitHub Packages の Container Registry にデプロイする
+  - GitHub Packages の Container registry にデプロイする
 
 ### ワークショップに必要な準備
 
@@ -82,7 +82,7 @@ CI の次は継続的デリバリー（CD）を体験してみましょう。
 デプロイしたい先にしたがって、リンク先にお進みください。
 
   - [Microsoft Azure の Web App へデプロイする](./continuous-deployment/deploy-to-azure-web-app.md)
-  - [GitHub Packages の Container Registry に push する](./continuous-deployment/push-container-image-to-github-packages.md)
+  - [GitHub Packages の Container registry で公開する](./continuous-deployment/push-container-image-to-github-packages.md)
 
 ## Congraturations 🎉
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - 1. [はじめての GitHub Actions のワークフローを作成する](#1-はじめての-github-actions-のワークフローを作成する)
 - 2. Node.js 製ウェブアプリで、継続的インテグレーション (CI) を行う
 - 3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う
-  - Microsoft Azure Web App へデプロイする
+  - Microsoft Azure の Web App へデプロイする
   - GitHub Packages の Container Registry にデプロイする
 
 ### ワークショップに必要な準備
@@ -36,21 +36,21 @@ GitHub Learning Lab のコースでは、日本語を選べるものもありま
 
 コースの学習を始めるには「Start free course」ボタンを選択して進めます。演習用のリポジトリを Public または Private のどちらに作成するか聞かれますので、特段理由がなければ、「Public」を選択し進めてください。
 
-<img src="./images/github-learning-lab_github-actions-hello-world_001.png" width="80%" alt="キャプチャ画像: 「Start free course」を選択する" title="「Start free course」を選択する">
+<img src="./images/github-learning-lab_github-actions-hello-world_001.png" width="80%" alt="キャプチャ画像: 「Start free course」を選択する" title="「Start free course」を選択する"><br/>
 
-![キャプチャ画像: 「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む](./images/github-learning-lab_github-actions-hello-world_002.png "「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む")
+<img src="./images/github-learning-lab_github-actions-hello-world_002.png" width="80%" alt="キャプチャ画像: 「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む" title="「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む"><br/>
 
 リポジトリの準備ができたら、「Start: Add a Dockerfile」ボタンを選択し進めましょう。
 
-![キャプチャ画像: 「Satrt: Add a Dockerfile」ボタンを選択し、コースを開始する](./images/github-learning-lab_github-actions-hello-world_003.png "「Satrt: Add a Dockerfile」ボタンを選択し、コースを開始する")
+<img src="./images/github-learning-lab_github-actions-hello-world_003.png" width="80%" alt="キャプチャ画像: 「Satrt: Add a Dockerfile」ボタンを選択し、コースを開始する" title="「Satrt: Add a Dockerfile」ボタンを選択し、コースを開始する"><br/>
 
 この GitHub Learning Lab では、Docker container を使ってオリジナルのアクションを作ります。実際のところ、ワークフローを組む際は既存のアクションを利用することが多いですが、どうしても必要な処理ができるアクションがない、独自処理を再利用できるようにしたい場合には有効です。
 
 さて、 Congraturations! までたどり着けましたか？ GitHub での進捗は、GitHub Learning Lab にも反映されます。なんどでも履修できるので、不安のあるときは見返してみるとよいでしょう。
 
-![](./images/github-learning-lab_github-actions-hello-world_004.png)
+<img src="./images/github-learning-lab_github-actions-hello-world_004.png" width="60%" alt="キャプチャ画像: コースを完了すると Congratulations! と表示される" title="コースを完了すると Congratulations! と表示される"><br/>
 
-![](./images/github-learning-lab_github-actions-hello-world_005.png)
+<img src="./images/github-learning-lab_github-actions-hello-world_005.png" width="80%" alt="キャプチャ画像: GitHub Learning Lab のコースの画面では進捗を確認できる" title="GitHub Learning Lab のコースの画面では進捗を確認できる"><br/>
 
 さいごに、Microsoft Learn の画面に戻り、「知識チェック」を試してみましょう。「回答を確認」で全問正解できればクリアです！「続行 >」ボタンを選択し、モジュールを終えましょう🎉
 
@@ -112,7 +112,7 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 | Monitoring タブ | 今回は設定不要 |
 | Tags タブ | 今回は設定不要 |
 
-![](./images/azure_create-web-app_001.png)
+<img src="./images/azure_create-web-app_001.png" width="90%" alt="キャプチャ画像: Azure Web App を新規作成する" title="Azure Web App を新規作成する"><br/>
 
 リソース名は、この推奨される省略形を利用すると、識別しやすくなります。
 
@@ -134,35 +134,35 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 | Build > Runtime stack | 利用するランタイムスタックを選択（前述のクイックスタートのコードを利用される方は「Node」を選択） |
 | Build > Version | 利用する言語のバージョンを選択（前述のクイックスタートのコードを利用される方は「Node 14 LTS」を選択） |
 
-![](./images/azure_app-service_deployment-center_001.png)
+<img src="./images/azure_app-service_deployment-center_001.png" width="90%" alt="キャプチャ画像: Azure Web App の Deployment Center で設定する" title="Azure Web App の Deployment Center で設定する"><br/>
 
 ここまで入力し、「Preview file」を選択すると、生成されるワークフローのコードを確認することができます。
 
-![](./images/azure_app-service_deployment-center_002.png)
+<img src="./images/azure_app-service_deployment-center_002.png" width="90%" alt="キャプチャ画像: Workflow Configuration のプレビューを確認する" title="Workflow Configuration のプレビューを確認する"><br/>
 
 問題なければ、画面上部の「Save」を選択し保存します。
 
-![](./images/azure_app-service_deployment-center_003.png)
+<img src="./images/azure_app-service_deployment-center_003.png" width="80%" alt="キャプチャ画像: 「Save」ボタンを選択し、Development Center の設定内容を保存する" title="「Save」ボタンを選択し、Development Center の設定内容を保存する"><br/>
 
 設定した GitHub リポジトリを開き、作成されたワークフローファイルやアクションの実行状況を見てみましょう。
 
 `.github/workflows` ディレクトリに新しくワークフローファイルが作成され、先ほど Azure ポータルの「Preview file」で表示したコードが反映されていることがわかります。
 
-![](./images/github-workflow_by-azure-app-service-deployment-center_001.png)
+<img src="./images/github-workflow_by-azure-app-service-deployment-center_001.png" width="90%" alt="キャプチャ画像: GitHub のリポジトリに `.github/workflows` ディレクトリが作成されている" title="GitHub のリポジトリに `.github/workflows` ディレクトリが作成されている"><br/>
 
-![](./images/github-workflow_by-azure-app-service-deployment-center_002.png)
+<img src="./images/github-workflow_by-azure-app-service-deployment-center_002.png" width="90%" alt="キャプチャ画像: Azure Web App の Deployment Center から作成したワークフローを確認する" title="Azure Web App の Deployment Center から作成したワークフローを確認する"><br/>
 
 つぎに、アクションの実行状況を見てみると、先ほど作成した Web App にデプロイされていることがわかります。
 
-![](./images/github-workflow_by-azure-app-service-deployment-center_003.png)
+<img src="./images/github-workflow_by-azure-app-service-deployment-center_003.png" width="90%" alt="キャプチャ画像: GitHub リポジトリで「Actions」タブを開きワークフローの実行状況を確認する" title="GitHub リポジトリで「Actions」タブを開きワークフローの実行状況を確認する"><br/>
 
-![](./images/github-workflow_by-azure-app-service-deployment-center_004.png)
+<img src="./images/github-workflow_by-azure-app-service-deployment-center_004.png" width="90%" alt="キャプチャ画像: 個別のワークフローの実行状況を開き、確認する" title="個別のワークフローの実行状況を開き、確認する"><br/>
 
-![](./images/github-workflow_by-azure-app-service-deployment-center_005.png)
+<img src="./images/github-workflow_by-azure-app-service-deployment-center_005.png" width="90%" alt="キャプチャ画像: ワークフローの各ジョブ、各ステップの実行状況を確認できる" title="ワークフローの各ジョブ、各ステップの実行状況を確認できる"><br/>
 
 Web App の URL を開くと、紐づけた GitHub リポジトリのコードが反映されていることがわかります。
 
-![](./images/displayed-hello-world_001.png)
+<img src="./images/displayed-hello-world_001.png" width="90%" alt="キャプチャ画像: Web App の URL を開き、デプロイが反映されていることを確認する" title="Web App の URL を開き、デプロイが反映されていることを確認する"><br/>
 
 ### `Azure/webapps-deploy` アクションについて
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@
 
 このワークショップでは、 [Microsoft Learn](https://docs.microsoft.com/ja-jp/learn/) や [GitHub Learning Lab](https://lab.github.com/) を用いて学習を進めます。
 
-- 1. はじめての GitHub Actions のワークフローを作成する
+- 1. [はじめての GitHub Actions のワークフローを作成する](#1-はじめての-github-actions-のワークフローを作成する)
 - 2. Node.js 製ウェブアプリで、継続的インテグレーション (CI) を行う
-- 3. Node.js 製ウェブアプリを Azure Web App へデプロイする
+- 3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う
+  - Microsoft Azure Web App へデプロイする
+  - GitHub Packages の Container Registry にデプロイする
 
 ### ワークショップに必要な準備
 
-| 項目 | 説明 |
-|----|----|
-| GitHub アカウント | 実際に GitHub にリポジトリを作って作業するため、 GitHub アカウントをご用意ください。新しく作成する方は [こちら](https://github.com/join) から作成してください。 |
-| Azure アカウント | 実際にアプリケーションを Azure Web App にデプロイするため、 Azure アカウントをご用意ください。新しく作成する方は [こちら](https://azure.microsoft.com/ja-jp/free/) から作成してください。 |
-
-また、学習に利用する Microsoft Learn は、Microsoft アカウント、組織アカウントまたはGitHub アカウントでサインインするとコンテンツの実施状況を記録できます。適宜サインインしてご利用ください。
+| 項目 | 要否 | 説明 |
+|----|----|----|
+| GitHub アカウント | 必須 | 実際に GitHub にリポジトリを作って作業するため、 GitHub アカウントをご用意ください。新しく作成する方は [こちら](https://github.com/join) から作成してください。 |
+| Microsoft アカウント | (説明参照) | 本ワークショップで利用する Microsoft Learn は、Microsoft アカウントでサインインすると学習記録を記録することができます。サインインせずに利用することもできるので、ご自身の用途によって適宜ご利用ください。新しく作成される方は [こちら](https://account.microsoft.com/account/Account) から作成してください。 |
+| Azure アカウント | (説明参照) | Microsoft Azure へのデプロイを体験する場合は、Azure アカウントをご用意ください。新しく作成する方は [こちら](https://azure.microsoft.com/ja-jp/free/) から作成してください。 |
 
 ## 1. はじめての GitHub Actions のワークフローを作成する
 
@@ -35,12 +36,13 @@ GitHub Learning Lab のコースでは、日本語を選べるものもありま
 
 コースの学習を始めるには「Start free course」ボタンを選択して進めます。演習用のリポジトリを Public または Private のどちらに作成するか聞かれますので、特段理由がなければ、「Public」を選択し進めてください。
 
-![](./images/github-learning-lab_github-actions-hello-world_001.png)
-![](./images/github-learning-lab_github-actions-hello-world_002.png)
+<img src="./images/github-learning-lab_github-actions-hello-world_001.png" width="320px" alt="キャプチャ画像: 「Start free course」を選択する" title="「Start free course」を選択する">
+
+![キャプチャ画像: 「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む](./images/github-learning-lab_github-actions-hello-world_002.png "「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む")
 
 リポジトリの準備ができたら、「Start: Add a Dockerfile」ボタンを選択し進めましょう。
 
-![](./images/github-learning-lab_github-actions-hello-world_003.png)
+![キャプチャ画像: 「Satrt: Add a Dockerfile」ボタンを選択し、コースを開始する](./images/github-learning-lab_github-actions-hello-world_003.png "「Satrt: Add a Dockerfile」ボタンを選択し、コースを開始する")
 
 この GitHub Learning Lab では、Docker container を使ってオリジナルのアクションを作ります。実際のところ、ワークフローを組む際は既存のアクションを利用することが多いですが、どうしても必要な処理ができるアクションがない、独自処理を再利用できるようにしたい場合には有効です。
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - [1. はじめての GitHub Actions のワークフローを作成する](#1-はじめての-github-actions-のワークフローを作成する)
 - [2. Node.js 製ウェブアプリで、継続的インテグレーション (CI) を行う](#2-nodejs-製ウェブアプリで継続的インテグレーション-ci-を行う)
-- [3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う](#3-nodejs-製ウェブアプリで継続的デプロイ-cd-を行う)
+- [3. Node.js 製ウェブアプリで、継続的デプロイ (CD) を行う](#3-nodejs-製ウェブアプリで継続的デプロイ-cd-を行う)
   - Microsoft Azure の Web App へデプロイする
   - GitHub Packages の Container Registry にデプロイする
 
@@ -75,7 +75,7 @@ GitHub での進捗は、GitHub Learning Lab にも反映されます。なん�
 
 GitHub Learning Lab での演習が終わったら、Microsoft Learn に戻り「知識チェック」を済ませてモジュールを完了しましょう。
 
-## 3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う
+## 3. Node.js 製ウェブアプリで、継続的デプロイ (CD) を行う
 
 デプロイしたい先にしたがって、リンク先にお進みください。
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 このワークショップでは、 [Microsoft Learn](https://docs.microsoft.com/ja-jp/learn/) や [GitHub Learning Lab](https://lab.github.com/) を用いて学習を進めます。
 
-- 1. [はじめての GitHub Actions のワークフローを作成する](#1-はじめての-github-actions-のワークフローを作成する)
-- 2. Node.js 製ウェブアプリで、継続的インテグレーション (CI) を行う
-- 3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う
+- [1. はじめての GitHub Actions のワークフローを作成する](#1-はじめての-github-actions-のワークフローを作成する)
+- [2. Node.js 製ウェブアプリで、継続的インテグレーション (CI) を行う](#2-nodejs-製ウェブアプリで継続的インテグレーション-ci-を行う)
+- [3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う](#3-nodejs-製ウェブアプリで継続的デプロイ-cd-を行う)
   - Microsoft Azure の Web App へデプロイする
   - GitHub Packages の Container Registry にデプロイする
 
@@ -46,9 +46,11 @@ GitHub Learning Lab のコースでは、日本語を選べるものもありま
 
 この GitHub Learning Lab では、Docker container を使ってオリジナルのアクションを作ります。実際のところ、ワークフローを組む際は既存のアクションを利用することが多いですが、どうしても必要な処理ができるアクションがない、独自処理を再利用できるようにしたい場合には有効です。
 
-さて、 Congraturations! までたどり着けましたか？ GitHub での進捗は、GitHub Learning Lab にも反映されます。なんどでも履修できるので、不安のあるときは見返してみるとよいでしょう。
+さて、 Congraturations! までたどり着けましたか？
 
 <img src="./images/github-learning-lab_github-actions-hello-world_004.png" width="60%" alt="キャプチャ画像: コースを完了すると Congratulations! と表示される" title="コースを完了すると Congratulations! と表示される"><br/>
+
+GitHub での進捗は、GitHub Learning Lab にも反映されます。なんどでも履修できるので、不安のあるときは見返してみるとよいでしょう。
 
 <img src="./images/github-learning-lab_github-actions-hello-world_005.png" width="80%" alt="キャプチャ画像: GitHub Learning Lab のコースの画面では進捗を確認できる" title="GitHub Learning Lab のコースの画面では進捗を確認できる"><br/>
 
@@ -73,121 +75,12 @@ GitHub Learning Lab のコースでは、日本語を選べるものもありま
 
 GitHub Learning Lab での演習が終わったら、Microsoft Learn に戻り「知識チェック」を済ませてモジュールを完了しましょう。
 
-## 3. Node.js 製ウェブアプリを Azure Web App へデプロイする
+## 3. Node.js 製ウェブアプリで、継続的デプロイ（CD）を行う
 
-CI の次は継続的デリバリー（CD）を体験してみましょう。GitHub Actions を利用しウェブアプリを Azure Web App へデプロイします。
+デプロイしたい先にしたがって、リンク先にお進みください。
 
-Azure Web App は様々な言語に対応した PaaS サービスです。詳細は下記ドキュメントなどをご参照ください。
-
-- [概要 - Azure App Service | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/app-service/overview)
-
-ここでは、下記のドキュメントを参考に学習を進めます。
-
-- [Continuous deployment to Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github)
-  - ※ 日本語の記事の更新が追いついておらず GitHub Actions の記載がないため、英語のドキュメントを参照します。
-
-大まかな流れは下記のとおりです。
-
-1. ウェブアプリのコードを用意する
-1. Azure Web App のリソースを作成する
-1. Azure ポータルから Deployment Center を設定する
-
-なお、Microsoft Learn にも Azure Web App へデプロイするシナリオのモジュール [GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) があります。こちらは、Docker コンテナのイメージを作成し、Azure Web App for Containers へデプロイする方法を学ぶことができます。ご興味ある方はご参考ください。
-
-それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
-](https://docs.microsoft.com/ja-jp/azure/app-service/quickstart-nodejs?pivots=platform-windows) で利用されているコードです。）
-
-つぎに、Azure Web App のリソースを作成しましょう。Runtime stack を前述で用意したコードに一致するよう選択し、その他の項目は適宜設定してリソースを作成してください。参考として、下記の設定で作成します。
-
-| 項目 | 説明 |
-|----|----|
-| Resource Group | 「Create new」を選択し、`rg-` で始まる文字列で作成 |
-| Name | `app-` で始まる文字列で作成 |
-| Publish | 「Code」を選択 |
-| Runtime stack | 「Node.js 14 LTS」を選択 |
-| Operationg System | 「Windows」を選択 |
-| Region | 最寄りのリージョン（「Japan East」など）を選択 |
-| App Service Plan | 「Create new」を選択し、 `plan-` で始まる文字列で作成 |
-| Sku and size | 「Free F1」 |
-| Monitoring タブ | 今回は設定不要 |
-| Tags タブ | 今回は設定不要 |
-
-<img src="./images/azure_create-web-app_001.png" width="90%" alt="キャプチャ画像: Azure Web App を新規作成する" title="Azure Web App を新規作成する"><br/>
-
-リソース名は、この推奨される省略形を利用すると、識別しやすくなります。
-
-- [Azure リソースの種類に推奨される省略形 - Cloud Adoption Framework | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
-
-リソースの作成が完了したら、作成直後のウェブアプリの様子を確認しておきましょう。「Go to resource」ボタンから作成したリソースの画面に遷移し、「Overview」で「URL」を参照します。
-
-それでは、早速 Deployment Center から GitHub Actions を設定しましょう！
-
-左のメニューから「Deployment Center」を選択肢画面に遷移します。「Seettings」タブを開き、各項目を設定します。
-
-| 設定項目 | 説明 |
-|----|----|
-| Source | 「GitHub」を選択 |
-| GitHub > Authorize （または Signed in as） | 利用する GitHub アカウントでサインインし接続。サインイン済みでアカウントを変えたい場合は「Change Account」から変更 |
-| GitHub > Organization | GitHub アカウントと同名の文字列、または利用したい組織を選択 |
-| GitHub > Repository | 利用するリポジトリを選択（前述のクイックスタートのコードを利用される方は「nodejs-docs-hello-world」を選択） |
-| GitHub > Branch | 利用するブランチを選択（前述のクイックスタートのコードを利用される方は「master」を選択） |
-| Build > Runtime stack | 利用するランタイムスタックを選択（前述のクイックスタートのコードを利用される方は「Node」を選択） |
-| Build > Version | 利用する言語のバージョンを選択（前述のクイックスタートのコードを利用される方は「Node 14 LTS」を選択） |
-
-<img src="./images/azure_app-service_deployment-center_001.png" width="90%" alt="キャプチャ画像: Azure Web App の Deployment Center で設定する" title="Azure Web App の Deployment Center で設定する"><br/>
-
-ここまで入力し、「Preview file」を選択すると、生成されるワークフローのコードを確認することができます。
-
-<img src="./images/azure_app-service_deployment-center_002.png" width="90%" alt="キャプチャ画像: Workflow Configuration のプレビューを確認する" title="Workflow Configuration のプレビューを確認する"><br/>
-
-問題なければ、画面上部の「Save」を選択し保存します。
-
-<img src="./images/azure_app-service_deployment-center_003.png" width="80%" alt="キャプチャ画像: 「Save」ボタンを選択し、Development Center の設定内容を保存する" title="「Save」ボタンを選択し、Development Center の設定内容を保存する"><br/>
-
-設定した GitHub リポジトリを開き、作成されたワークフローファイルやアクションの実行状況を見てみましょう。
-
-`.github/workflows` ディレクトリに新しくワークフローファイルが作成され、先ほど Azure ポータルの「Preview file」で表示したコードが反映されていることがわかります。
-
-<img src="./images/github-workflow_by-azure-app-service-deployment-center_001.png" width="90%" alt="キャプチャ画像: GitHub のリポジトリに `.github/workflows` ディレクトリが作成されている" title="GitHub のリポジトリに `.github/workflows` ディレクトリが作成されている"><br/>
-
-<img src="./images/github-workflow_by-azure-app-service-deployment-center_002.png" width="90%" alt="キャプチャ画像: Azure Web App の Deployment Center から作成したワークフローを確認する" title="Azure Web App の Deployment Center から作成したワークフローを確認する"><br/>
-
-つぎに、アクションの実行状況を見てみると、先ほど作成した Web App にデプロイされていることがわかります。
-
-<img src="./images/github-workflow_by-azure-app-service-deployment-center_003.png" width="90%" alt="キャプチャ画像: GitHub リポジトリで「Actions」タブを開きワークフローの実行状況を確認する" title="GitHub リポジトリで「Actions」タブを開きワークフローの実行状況を確認する"><br/>
-
-<img src="./images/github-workflow_by-azure-app-service-deployment-center_004.png" width="90%" alt="キャプチャ画像: 個別のワークフローの実行状況を開き、確認する" title="個別のワークフローの実行状況を開き、確認する"><br/>
-
-<img src="./images/github-workflow_by-azure-app-service-deployment-center_005.png" width="90%" alt="キャプチャ画像: ワークフローの各ジョブ、各ステップの実行状況を確認できる" title="ワークフローの各ジョブ、各ステップの実行状況を確認できる"><br/>
-
-Web App の URL を開くと、紐づけた GitHub リポジトリのコードが反映されていることがわかります。
-
-<img src="./images/displayed-hello-world_001.png" width="90%" alt="キャプチャ画像: Web App の URL を開き、デプロイが反映されていることを確認する" title="Web App の URL を開き、デプロイが反映されていることを確認する"><br/>
-
-### `Azure/webapps-deploy` アクションについて
-
-自動生成されたワークフローファイルでは、 [Azure/webapps-deploy](https://github.com/Azure/webapps-deploy) アクションを利用して Azure Web App にデプロイしています。
-
-Azure Web App にデプロイするには認証が必要で、このアクションでは、２通りのやり方が提供されています。詳しくはドキュメントをご参照ください。
-
-| 認証方法 | 説明 |
-|----|----|
-| パブリッシュプロファイルを利用する | Azureポータルなどを使用し「デプロイ資格情報」を取得し、`Azure/webapps-deploy` のプロパティ `publish-profile` に指定（指定するときは GitHub Actions のシークレット機能を利用） |
-| `Azure/login` アクションを利用する | サービスプリンシパルを用いて [Azure/login](https://github.com/Azure/login) アクションと組合せて認証 |
-
-なお、ワークフローを実行する環境のセットアップついては、各言語に合わせたガイドがあるのでご参照ください。
-
-- [ガイド - GitHub Docs](https://docs.github.com/ja/actions/guides)
-
-また、Azure Function へのデプロイには、[Azure/functions-action](https://github.com/Azure/functions-action) を利用できます。詳しくは下記をご参照ください。
-
-- [GitHub Actions を使用した Azure Functions のコードの更新 | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions?tabs=dotnet)
-
-### リソースの削除
-
-Azure で作成したリソースは、リソースグループごと削除することがおすすめです。リソースグループの画面を開き、画面上部の「Delete resource group」から削除します。
-
-GitHub リポジトリは、「Settings」タブを開き、画面下部の「Delete this repository」を選択してください。一度削除すると復元できないので、よく確認の上操作を行ってください。
+  - [Microsoft Azure の Web App へデプロイする](./continuous-deployment/deploy-to-azure-web-app.md)
+  - GitHub Packages の Container Registry にデプロイする
 
 ## Congraturations 🎉
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ GitHub Learning Lab のコースでは、日本語を選べるものもありま
 
 コースの学習を始めるには「Start free course」ボタンを選択して進めます。演習用のリポジトリを Public または Private のどちらに作成するか聞かれますので、特段理由がなければ、「Public」を選択し進めてください。
 
-<img src="./images/github-learning-lab_github-actions-hello-world_001.png" width="320px" alt="キャプチャ画像: 「Start free course」を選択する" title="「Start free course」を選択する">
+<img src="./images/github-learning-lab_github-actions-hello-world_001.png" width="80%" alt="キャプチャ画像: 「Start free course」を選択する" title="「Start free course」を選択する">
 
 ![キャプチャ画像: 「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む](./images/github-learning-lab_github-actions-hello-world_002.png "「Public」を選択し、「Begin GitHub Actions: Hello World」ボタンを選択して進む")
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ GitHub Learning Lab での演習が終わったら、Microsoft Learn に戻り�
 
 ## 3. Node.js 製ウェブアプリで、継続的デプロイ (CD) を行う
 
+CI の次は継続的デリバリー（CD）を体験してみましょう。
+
 デプロイしたい先にしたがって、リンク先にお進みください。
 
   - [Microsoft Azure の Web App へデプロイする](./continuous-deployment/deploy-to-azure-web-app.md)
-  - [GitHub Packages の Container Registry にデプロイする](./continuous-deployment/push-container-image-to-github-packages.md)
+  - [GitHub Packages の Container Registry に push する](./continuous-deployment/push-container-image-to-github-packages.md)
 
 ## Congraturations 🎉
 

--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -1,6 +1,6 @@
 # Node.js 製ウェブアプリを Microsoft Azure の Web App へデプロイする
 
-CI の次は継続的デリバリー（CD）を体験してみましょう。GitHub Actions を利用しウェブアプリを Azure Web App へデプロイします。
+GitHub Actions を利用し、ウェブアプリを Azure Web App へデプロイします。
 
 Azure Web App は様々な言語に対応した PaaS サービスです。詳細は下記ドキュメントなどをご参照ください。
 
@@ -26,14 +26,15 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 - [3. Azure ポータルから Deployment Center を設定する](#3-azure-ポータルから-deployment-center-を設定する)
 - [4. リソースを削除する](#4-リソースを削除する)
 
-## 1. ウェブアプリのコードを用意する
+## 手順
+### 1. ウェブアプリのコードを用意する
 
 それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。
 
 とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
 ](https://docs.microsoft.com/ja-jp/azure/app-service/quickstart-nodejs?pivots=platform-windows) で利用されているコードです。）
 
-## 2. Azure Web App のリソースを作成する
+### 2. Azure Web App のリソースを作成する
 
 つぎに、Azure Web App のリソースを作成しましょう。Runtime stack を前述で用意したコードに一致するよう選択し、その他の項目は適宜設定してリソースを作成してください。参考として、下記の設定で作成します。
 
@@ -58,7 +59,7 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 
 リソースの作成が完了したら、作成直後のウェブアプリの様子を確認しておきましょう。「Go to resource」ボタンから作成したリソースの画面に遷移し、「Overview」で「URL」を参照します。
 
-## 3. Azure ポータルから Deployment Center を設定する
+### 3. Azure ポータルから Deployment Center を設定する
 
 それでは、早速 Deployment Center から GitHub Actions を設定しましょう！
 
@@ -104,7 +105,7 @@ Web App の URL を開くと、紐づけた GitHub リポジトリのコード�
 
 <img src="../images/displayed-hello-world_001.png" width="90%" alt="キャプチャ画像: Web App の URL を開き、デプロイが反映されていることを確認する" title="Web App の URL を開き、デプロイが反映されていることを確認する"><br/>
 
-### `Azure/webapps-deploy` アクションについて
+#### `Azure/webapps-deploy` アクションについて
 
 自動生成されたワークフローファイルでは、 [Azure/webapps-deploy](https://github.com/Azure/webapps-deploy) アクションを利用して Azure Web App にデプロイしています。
 
@@ -123,7 +124,7 @@ Azure Web App にデプロイするには認証が必要で、このアクショ
 
 - [GitHub Actions を使用した Azure Functions のコードの更新 | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions?tabs=dotnet)
 
-## 4. リソースを削除する
+### 4. リソースを削除する
 
 Azure で作成したリソースは、リソースグループごと削除することがおすすめです。リソースグループの画面を開き、画面上部の「Delete resource group」から削除します。
 

--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -11,17 +11,17 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 - [Continuous deployment to Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github)
   - ※ 日本語の記事の更新が追いついておらず GitHub Actions の記載がないため、英語のドキュメントを参照します。
 
-大まかな流れは下記のとおりです。
-
-1. ウェブアプリのコードを用意する
-1. Azure Web App のリソースを作成する
-1. Azure ポータルから Deployment Center を設定する
-
 <details><summary>備考: Microsoft Learn の関連コンテンツ</summary>
 
 なお、Microsoft Learn にも Azure Web App へデプロイするシナリオのモジュール [GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) があります。こちらは、Docker コンテナのイメージを作成し、Azure Web App for Containers へデプロイする方法を学ぶことができます。ご興味ある方はご参考ください。
 
 </details>
+
+大まかな流れは下記のとおりです。
+
+1. ウェブアプリのコードを用意する
+1. Azure Web App のリソースを作成する
+1. Azure ポータルから Deployment Center を設定する
 
 それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
 ](https://docs.microsoft.com/ja-jp/azure/app-service/quickstart-nodejs?pivots=platform-windows) で利用されているコードです。）

--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -12,9 +12,11 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
   - ※ 日本語の記事の更新が追いついておらず GitHub Actions の記載がないため、英語のドキュメントを参照します。
 
 <details><summary>備考: Microsoft Learn の関連コンテンツ</summary>
+<p>
 
 なお、Microsoft Learn にも Azure Web App へデプロイするシナリオのモジュール [GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) があります。こちらは、Docker コンテナのイメージを作成し、Azure Web App for Containers へデプロイする方法を学ぶことができます。ご興味ある方はご参考ください。
 
+</p>
 </details>
 
 大まかな流れは下記のとおりです。

--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -17,7 +17,11 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 1. Azure Web App のリソースを作成する
 1. Azure ポータルから Deployment Center を設定する
 
+<details><summary>備考: Microsoft Learn の関連コンテンツ</summary>
+
 なお、Microsoft Learn にも Azure Web App へデプロイするシナリオのモジュール [GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) があります。こちらは、Docker コンテナのイメージを作成し、Azure Web App for Containers へデプロイする方法を学ぶことができます。ご興味ある方はご参考ください。
+
+</details>
 
 それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
 ](https://docs.microsoft.com/ja-jp/azure/app-service/quickstart-nodejs?pivots=platform-windows) で利用されているコードです。）

--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -1,4 +1,4 @@
-## Node.js 製ウェブアプリを Microsoft Azure の Web App へデプロイする
+# Node.js 製ウェブアプリを Microsoft Azure の Web App へデプロイする
 
 CI の次は継続的デリバリー（CD）を体験してみましょう。GitHub Actions を利用しウェブアプリを Azure Web App へデプロイします。
 
@@ -21,12 +21,19 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 
 大まかな流れは下記のとおりです。
 
-1. ウェブアプリのコードを用意する
-1. Azure Web App のリソースを作成する
-1. Azure ポータルから Deployment Center を設定する
+- [1. ウェブアプリのコードを用意する](#1-ウェブアプリのコードを用意する)
+- [2. Azure Web App のリソースを作成する](#2-azure-web-app-のリソースを作成する)
+- [3. Azure ポータルから Deployment Center を設定する](#3-azure-ポータルから-deployment-center-を設定する)
+- [4. リソースを削除する](#4-リソースを削除する)
 
-それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
+## 1. ウェブアプリのコードを用意する
+
+それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。
+
+とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
 ](https://docs.microsoft.com/ja-jp/azure/app-service/quickstart-nodejs?pivots=platform-windows) で利用されているコードです。）
+
+## 2. Azure Web App のリソースを作成する
 
 つぎに、Azure Web App のリソースを作成しましょう。Runtime stack を前述で用意したコードに一致するよう選択し、その他の項目は適宜設定してリソースを作成してください。参考として、下記の設定で作成します。
 
@@ -50,6 +57,8 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 - [Azure リソースの種類に推奨される省略形 - Cloud Adoption Framework | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
 
 リソースの作成が完了したら、作成直後のウェブアプリの様子を確認しておきましょう。「Go to resource」ボタンから作成したリソースの画面に遷移し、「Overview」で「URL」を参照します。
+
+## 3. Azure ポータルから Deployment Center を設定する
 
 それでは、早速 Deployment Center から GitHub Actions を設定しましょう！
 
@@ -114,7 +123,7 @@ Azure Web App にデプロイするには認証が必要で、このアクショ
 
 - [GitHub Actions を使用した Azure Functions のコードの更新 | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions?tabs=dotnet)
 
-### リソースの削除
+## 4. リソースを削除する
 
 Azure で作成したリソースは、リソースグループごと削除することがおすすめです。リソースグループの画面を開き、画面上部の「Delete resource group」から削除します。
 

--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -1,0 +1,115 @@
+## Node.js 製ウェブアプリを Microsoft Azure の Web App へデプロイする
+
+CI の次は継続的デリバリー（CD）を体験してみましょう。GitHub Actions を利用しウェブアプリを Azure Web App へデプロイします。
+
+Azure Web App は様々な言語に対応した PaaS サービスです。詳細は下記ドキュメントなどをご参照ください。
+
+- [概要 - Azure App Service | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/app-service/overview)
+
+ここでは、下記のドキュメントを参考に学習を進めます。
+
+- [Continuous deployment to Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github)
+  - ※ 日本語の記事の更新が追いついておらず GitHub Actions の記載がないため、英語のドキュメントを参照します。
+
+大まかな流れは下記のとおりです。
+
+1. ウェブアプリのコードを用意する
+1. Azure Web App のリソースを作成する
+1. Azure ポータルから Deployment Center を設定する
+
+なお、Microsoft Learn にも Azure Web App へデプロイするシナリオのモジュール [GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) があります。こちらは、Docker コンテナのイメージを作成し、Azure Web App for Containers へデプロイする方法を学ぶことができます。ご興味ある方はご参考ください。
+
+それではまず、デプロイに使用するウェブアプリとして、上記ドキュメントの「[Prepare your repository](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github#prepare-your-repository)」で言及されている条件を満たすコードを、自身の GitHub のリポジトリに用意します。とくに利用したいコードがない場合は、こちら [Azure-Samples/nodejs-docs-hello-world](https://github.com/Azure-Samples/nodejs-docs-hello-world) をフォークしてください。（クイックスタート: [Azure で Node.js Web アプリを作成する
+](https://docs.microsoft.com/ja-jp/azure/app-service/quickstart-nodejs?pivots=platform-windows) で利用されているコードです。）
+
+つぎに、Azure Web App のリソースを作成しましょう。Runtime stack を前述で用意したコードに一致するよう選択し、その他の項目は適宜設定してリソースを作成してください。参考として、下記の設定で作成します。
+
+| 項目 | 説明 |
+|----|----|
+| Resource Group | 「Create new」を選択し、`rg-` で始まる文字列で作成 |
+| Name | `app-` で始まる文字列で作成 |
+| Publish | 「Code」を選択 |
+| Runtime stack | 「Node.js 14 LTS」を選択 |
+| Operationg System | 「Windows」を選択 |
+| Region | 最寄りのリージョン（「Japan East」など）を選択 |
+| App Service Plan | 「Create new」を選択し、 `plan-` で始まる文字列で作成 |
+| Sku and size | 「Free F1」 |
+| Monitoring タブ | 今回は設定不要 |
+| Tags タブ | 今回は設定不要 |
+
+<img src="../images/azure_create-web-app_001.png" width="90%" alt="キャプチャ画像: Azure Web App を新規作成する" title="Azure Web App を新規作成する"><br/>
+
+リソース名は、この推奨される省略形を利用すると、識別しやすくなります。
+
+- [Azure リソースの種類に推奨される省略形 - Cloud Adoption Framework | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)
+
+リソースの作成が完了したら、作成直後のウェブアプリの様子を確認しておきましょう。「Go to resource」ボタンから作成したリソースの画面に遷移し、「Overview」で「URL」を参照します。
+
+それでは、早速 Deployment Center から GitHub Actions を設定しましょう！
+
+左のメニューから「Deployment Center」を選択肢画面に遷移します。「Seettings」タブを開き、各項目を設定します。
+
+| 設定項目 | 説明 |
+|----|----|
+| Source | 「GitHub」を選択 |
+| GitHub > Authorize （または Signed in as） | 利用する GitHub アカウントでサインインし接続。サインイン済みでアカウントを変えたい場合は「Change Account」から変更 |
+| GitHub > Organization | GitHub アカウントと同名の文字列、または利用したい組織を選択 |
+| GitHub > Repository | 利用するリポジトリを選択（前述のクイックスタートのコードを利用される方は「nodejs-docs-hello-world」を選択） |
+| GitHub > Branch | 利用するブランチを選択（前述のクイックスタートのコードを利用される方は「master」を選択） |
+| Build > Runtime stack | 利用するランタイムスタックを選択（前述のクイックスタートのコードを利用される方は「Node」を選択） |
+| Build > Version | 利用する言語のバージョンを選択（前述のクイックスタートのコードを利用される方は「Node 14 LTS」を選択） |
+
+<img src="../images/azure_app-service_deployment-center_001.png" width="90%" alt="キャプチャ画像: Azure Web App の Deployment Center で設定する" title="Azure Web App の Deployment Center で設定する"><br/>
+
+ここまで入力し、「Preview file」を選択すると、生成されるワークフローのコードを確認することができます。
+
+<img src="../images/azure_app-service_deployment-center_002.png" width="90%" alt="キャプチャ画像: Workflow Configuration のプレビューを確認する" title="Workflow Configuration のプレビューを確認する"><br/>
+
+問題なければ、画面上部の「Save」を選択し保存します。
+
+<img src="../images/azure_app-service_deployment-center_003.png" width="80%" alt="キャプチャ画像: 「Save」ボタンを選択し、Development Center の設定内容を保存する" title="「Save」ボタンを選択し、Development Center の設定内容を保存する"><br/>
+
+設定した GitHub リポジトリを開き、作成されたワークフローファイルやアクションの実行状況を見てみましょう。
+
+`.github/workflows` ディレクトリに新しくワークフローファイルが作成され、先ほど Azure ポータルの「Preview file」で表示したコードが反映されていることがわかります。
+
+<img src="../images/github-workflow_by-azure-app-service-deployment-center_001.png" width="90%" alt="キャプチャ画像: GitHub のリポジトリに `.github/workflows` ディレクトリが作成されている" title="GitHub のリポジトリに `.github/workflows` ディレクトリが作成されている"><br/>
+
+<img src="../images/github-workflow_by-azure-app-service-deployment-center_002.png" width="90%" alt="キャプチャ画像: Azure Web App の Deployment Center から作成したワークフローを確認する" title="Azure Web App の Deployment Center から作成したワークフローを確認する"><br/>
+
+つぎに、アクションの実行状況を見てみると、先ほど作成した Web App にデプロイされていることがわかります。
+
+<img src="../images/github-workflow_by-azure-app-service-deployment-center_003.png" width="90%" alt="キャプチャ画像: GitHub リポジトリで「Actions」タブを開きワークフローの実行状況を確認する" title="GitHub リポジトリで「Actions」タブを開きワークフローの実行状況を確認する"><br/>
+
+<img src="../images/github-workflow_by-azure-app-service-deployment-center_004.png" width="90%" alt="キャプチャ画像: 個別のワークフローの実行状況を開き、確認する" title="個別のワークフローの実行状況を開き、確認する"><br/>
+
+<img src="../images/github-workflow_by-azure-app-service-deployment-center_005.png" width="90%" alt="キャプチャ画像: ワークフローの各ジョブ、各ステップの実行状況を確認できる" title="ワークフローの各ジョブ、各ステップの実行状況を確認できる"><br/>
+
+Web App の URL を開くと、紐づけた GitHub リポジトリのコードが反映されていることがわかります。
+
+<img src="../images/displayed-hello-world_001.png" width="90%" alt="キャプチャ画像: Web App の URL を開き、デプロイが反映されていることを確認する" title="Web App の URL を開き、デプロイが反映されていることを確認する"><br/>
+
+### `Azure/webapps-deploy` アクションについて
+
+自動生成されたワークフローファイルでは、 [Azure/webapps-deploy](https://github.com/Azure/webapps-deploy) アクションを利用して Azure Web App にデプロイしています。
+
+Azure Web App にデプロイするには認証が必要で、このアクションでは、２通りのやり方が提供されています。詳しくはドキュメントをご参照ください。
+
+| 認証方法 | 説明 |
+|----|----|
+| パブリッシュプロファイルを利用する | Azureポータルなどを使用し「デプロイ資格情報」を取得し、`Azure/webapps-deploy` のプロパティ `publish-profile` に指定（指定するときは GitHub Actions のシークレット機能を利用） |
+| `Azure/login` アクションを利用する | サービスプリンシパルを用いて [Azure/login](https://github.com/Azure/login) アクションと組合せて認証 |
+
+なお、ワークフローを実行する環境のセットアップついては、各言語に合わせたガイドがあるのでご参照ください。
+
+- [ガイド - GitHub Docs](https://docs.github.com/ja/actions/guides)
+
+また、Azure Function へのデプロイには、[Azure/functions-action](https://github.com/Azure/functions-action) を利用できます。詳しくは下記をご参照ください。
+
+- [GitHub Actions を使用した Azure Functions のコードの更新 | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/azure-functions/functions-how-to-github-actions?tabs=dotnet)
+
+### リソースの削除
+
+Azure で作成したリソースは、リソースグループごと削除することがおすすめです。リソースグループの画面を開き、画面上部の「Delete resource group」から削除します。
+
+GitHub リポジトリは、「Settings」タブを開き、画面下部の「Delete this repository」を選択してください。一度削除すると復元できないので、よく確認の上操作を行ってください。

--- a/continuous-deployment/push-container-image-to-github-packages.md
+++ b/continuous-deployment/push-container-image-to-github-packages.md
@@ -1,0 +1,5 @@
+# Node.js 製ウェブアプリを GitHub Packages の Container Registry にデプロイする
+
+（作成中）
+
+- [GitHub Actions を活用して GitHub Packages に公開する - Learn | Microsoft Docs](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-packages/)

--- a/continuous-deployment/push-container-image-to-github-packages.md
+++ b/continuous-deployment/push-container-image-to-github-packages.md
@@ -1,5 +1,39 @@
-# Node.js 製ウェブアプリを GitHub Packages の Container Registry にデプロイする
+# Node.js 製ウェブアプリを GitHub Packages の Container Registry に push する
 
 （作成中）
 
-- [GitHub Actions を活用して GitHub Packages に公開する - Learn | Microsoft Docs](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-packages/)
+## 概要
+
+サービスの運用にコンテナを利用しているプロジェクトを想定し、GitHub Actions を用いてコンテナイメージをレジストリに push するワークフローを作成してみましょう。
+
+レジストリとして利用できるサービスはいくつかありますが、ここでは GitHub Packages の Container Registry を利用します。
+
+### GitHub Packages と Container Registry について
+
+**GitHub Packages** とは、様々な言語やコンテナのパッケージを、パブリックまたはプライベートに公開できるサービスです。
+
+- [GitHub Packages とは - GitHub Docs](https://docs.github.com/ja/packages/learn-github-packages/introduction-to-github-packages)
+
+そして、GitHub Packages の機能の一つである **Container Registry** は、コンテナイメージを保存・管理することができます。現在は、Docker および Open Container Initiative (OCI) 使用のコンテナフォーマットをサポートしています。
+
+- [GitHub Packages コンテナレジストリの利用 - GitHub Docs](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+
+### その他のレジストリサービス
+
+<details><summary>備考: Azure Container Registry を使ったデプロイ</summary>
+<p>
+
+なお、Microsoft Azure の Azure Container Registry と Azure Web Apps を利用したデプロイを知りたい方は、こちらの Microsoft Learn のモジュール[GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) がおすすめです。
+
+</p>
+</details>
+
+## 手順
+
+ここでは、このモジュールに沿って進めます。
+
+- Microsoft Learn: [GitHub Actions を活用して GitHub Packages に公開する - Learn | Microsoft Docs](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-packages/)
+
+演習では、 GitHub Learning Lab の [GitHub Actions: Publish to GitHub Packages | GitHub Learning Lab](https://lab.github.com/githubtraining/github-actions:-publish-to-github-packages) を実施します。このコースには、下記の内容が含まれています。
+
+- 

--- a/continuous-deployment/push-container-image-to-github-packages.md
+++ b/continuous-deployment/push-container-image-to-github-packages.md
@@ -46,9 +46,11 @@
 
 一点だけ、演習の内容を変更する必要があります。
 
-この演習では `docker.pkg.github.com` というレジストリに push する指示があるのですが、実はこのレジストリは、Container registry の前身である Docker registry のものです。
+この演習では `docker.pkg.github.com` というレジストリに push や pull を行う指示があるのですが、実はこのレジストリは、Container registry の前身である Docker registry のものです。
 
-Container registry では `ghcr.io` に変わるので、そのように指定します。
+Container registry では `ghcr.io` に変わるので、各工程で置き換えて進めてください。
+
+例えば、ワークフローの編集で `docker/build-push-action` アクションを記述する際は、このように指定します。
 
 ```yml
     - name: Build container image and push it
@@ -62,7 +64,11 @@ Container registry では `ghcr.io` に変わるので、そのように指定�
         tag_with_sha: true
 ```
 
-GitHub Learning Lab で作成したコンテナイメージを起動できましたか？ ブラウザで `http://localhost:8080` にアクセスすると、ビルドしたアプリケーション Tic Tac Toe (三目並べ) で遊ぶことができます。
+--
+
+さて、GitHub Learning Lab で作成したコンテナイメージを起動できましたか？
+
+ブラウザで `http://localhost:8080` にアクセスすると、ビルドしたアプリケーション Tic Tac Toe (三目並べ) で遊ぶことができます。
 
 さて、GitHub Learning Lab での演習が終わったら、Microsoft Learn に戻り「知識チェック」を済ませてモジュールを完了しましょう。
 

--- a/continuous-deployment/push-container-image-to-github-packages.md
+++ b/continuous-deployment/push-container-image-to-github-packages.md
@@ -1,4 +1,4 @@
-# Node.js 製ウェブアプリを GitHub Packages の Container registry に push する
+# Node.js 製ウェブアプリを GitHub Packages の Container registry で公開する
 
 ## 概要
 
@@ -12,7 +12,7 @@
 
 - [GitHub Packages とは - GitHub Docs](https://docs.github.com/ja/packages/learn-github-packages/introduction-to-github-packages)
 
-そして、GitHub Packages の機能の一つである **Container registry** は、コンテナイメージを保存・管理することができます。現在は、Docker および Open Container Initiative (OCI) 使用のコンテナフォーマットをサポートしています。
+そして、GitHub Packages の機能の一つである **Container registry** は、コンテナイメージを保存・管理することができます。現在は、Docker および Open Container Initiative (OCI) のコンテナフォーマットをサポートしています。詳細は下記ドキュメントをご参照ください。
 
 - [GitHub Packages コンテナレジストリの利用 - GitHub Docs](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 
@@ -32,11 +32,35 @@
 
 - Microsoft Learn: [GitHub Actions を活用して GitHub Packages に公開する - Learn | Microsoft Docs](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-packages/)
 
-演習では、 GitHub Learning Lab の [GitHub Actions: Publish to GitHub Packages | GitHub Learning Lab](https://lab.github.com/githubtraining/github-actions:-publish-to-github-packages) を実施します。このコースには、下記の内容が含まれています。
+このモジュールでは、 GitHub Packages のパッケージ管理機能と Container registry の両方を学習します。
 
-- ベースとなるワークフローのセットアップ（CI の処理が記載されている）
-- `docker/build-push-action` アクションを用いて、Docker コンテナイメージのビルドと push を行う
+パッケージ管理の例として Node.js の `npm` を用いて説明されます。npm レジストリの詳細については、下記ドキュメントをご参照ください。
+
+- [GitHub Packages npmレジストリの利用 - GitHub Docs](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)
+
+後半の演習では、 GitHub Learning Lab の [GitHub Actions: Publish to GitHub Packages](https://lab.github.com/githubtraining/github-actions:-publish-to-github-packages) を実施します。このコースには、下記の内容が含まれています。
+
+- ベースとなるワークフローのセットアップ（CI までの処理が記載されている）
+- `docker/build-push-action` アクションを用いて、Docker コンテナイメージのビルドと Container registry への push を行う
 - Personal access token を用いて、Container registry からイメージを取得し起動してみる
+
+一点だけ、演習の内容を変更する必要があります。
+
+この演習では `docker.pkg.github.com` というレジストリに push する指示があるのですが、実はこのレジストリは、Container registry の前身である Docker registry のものです。
+
+Container registry では `ghcr.io` に変わるので、そのように指定します。
+
+```yml
+    - name: Build container image and push it
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+        # registry: docker.pkg.github.com
+        registry: ghcr.io
+        repository: OWNER/github-actions-for-packages/tic-tac-toe
+        tag_with_sha: true
+```
 
 GitHub Learning Lab で作成したコンテナイメージを起動できましたか？ ブラウザで `http://localhost:8080` にアクセスすると、ビルドしたアプリケーション Tic Tac Toe (三目並べ) で遊ぶことができます。
 
@@ -46,10 +70,66 @@ GitHub Learning Lab で作成したコンテナイメージを起動できまし
 
 ### `docker/build-push-action` アクションについて
 
-`docker/build-push-action` は、 Docker イメージをビルドし指定したレジストリに push することができるアクションです。
+`docker/build-push-action` は、[Docker](https://github.com/docker) によって提供されている、Docker イメージをビルドし指定したレジストリに push することができるアクションです。
 
 さまざまな機能が提供されており、柔軟なワークフローの実現をサポートします。詳しくは Marketplace や当該リポジトリをご参照ください。
 
-- [docker/build-push-action - Build and push Docker images · Actions · GitHub Marketplace](https://github.com/marketplace/actions/build-and-push-docker-images)
-
 なお、GitHub Learning Lab の演習では `v1` が利用されていましたが、現在は Docker [Buildx](https://github.com/docker/buildx) に対応した `v2` がリリースされており、こちらの利用が推奨されています。実際に使う際は、よくご確認の上ご利用ください。
+
+- `docker/build-push-action`
+  - [Build and push Docker images · Actions · GitHub Marketplace](https://github.com/marketplace/actions/build-and-push-docker-images)
+  - [Upgrade notes - docker/build-push-action](https://github.com/docker/build-push-action/blob/master/UPGRADE.md)
+  - [Handle tags and labels with `docker/metadata-action` - docker/build-push-action](https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md)
+- `docker/login-action`: [Docker Login · Actions · GitHub Marketplace](https://github.com/marketplace/actions/docker-login)
+- `docker/metadata-action`: [Docker Metadata action · Actions · GitHub Marketplace](https://github.com/marketplace/actions/docker-metadata-action)
+
+#### `docker/build-push-action` のアップグレードのサンプル
+
+`docker/build-push-action@v1` のサンプル（演習から引用）
+```yml
+- name: Build container image and push it
+  uses: docker/build-push-action@v1
+  with:
+    username: ${{github.actor}}
+    password: ${{secrets.GITHUB_TOKEN}}
+    registry: ghcr.io
+    repository: OWNER/github-actions-for-packages/tic-tac-toe
+    tag_with_sha: true
+```
+
+`docker/build-push-action@v2` のサンプル（演習のコードを変換）
+```yml
+# Docker Buildx のセットアップ
+- name: Set up Docker Buildx
+  uses: docker/setup-buildx-action@v1
+
+# レジストリへログイン
+- name: Login to GitHub Container registry
+  uses: docker/login-action@v1
+  with:
+    registry: ghcr.io
+    username: ${{github.actor}}
+    password: ${{secrets.GITHUB_TOKEN}}
+
+# tag_with_sha: true に相当するタグを生成
+- name: Docker meta
+  id: meta
+  uses: docker/metadata-action@v3
+  with:
+    images: ghcr.io/OWNER/tic-tac-toe
+    tags: |
+      type=sha
+
+# Docker イメージをビルドし push する
+- name: Build container image and push it
+  uses: docker/build-push-action@v2
+  with:
+    push: true
+    tags: ${{ steps.meta.outputs.tags }}
+```
+
+### 旧 Docker registry について
+
+旧 Docker registry に関しては、下記をご参照ください。
+
+- [Migrating to the Container registry from the Docker registry - GitHub Docs](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry)

--- a/continuous-deployment/push-container-image-to-github-packages.md
+++ b/continuous-deployment/push-container-image-to-github-packages.md
@@ -1,29 +1,27 @@
-# Node.js 製ウェブアプリを GitHub Packages の Container Registry に push する
-
-（作成中）
+# Node.js 製ウェブアプリを GitHub Packages の Container registry に push する
 
 ## 概要
 
 サービスの運用にコンテナを利用しているプロジェクトを想定し、GitHub Actions を用いてコンテナイメージをレジストリに push するワークフローを作成してみましょう。
 
-レジストリとして利用できるサービスはいくつかありますが、ここでは GitHub Packages の Container Registry を利用します。
+レジストリとして利用できるサービスはいくつかありますが、ここでは GitHub Packages の Container registry を利用します。
 
-### GitHub Packages と Container Registry について
+### GitHub Packages と Container registry について
 
 **GitHub Packages** とは、様々な言語やコンテナのパッケージを、パブリックまたはプライベートに公開できるサービスです。
 
 - [GitHub Packages とは - GitHub Docs](https://docs.github.com/ja/packages/learn-github-packages/introduction-to-github-packages)
 
-そして、GitHub Packages の機能の一つである **Container Registry** は、コンテナイメージを保存・管理することができます。現在は、Docker および Open Container Initiative (OCI) 使用のコンテナフォーマットをサポートしています。
+そして、GitHub Packages の機能の一つである **Container registry** は、コンテナイメージを保存・管理することができます。現在は、Docker および Open Container Initiative (OCI) 使用のコンテナフォーマットをサポートしています。
 
 - [GitHub Packages コンテナレジストリの利用 - GitHub Docs](https://docs.github.com/ja/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 
 ### その他のレジストリサービス
 
-<details><summary>備考: Azure Container Registry を使ったデプロイ</summary>
+<details><summary>備考: Azure Container registry を使ったデプロイ</summary>
 <p>
 
-なお、Microsoft Azure の Azure Container Registry と Azure Web Apps を利用したデプロイを知りたい方は、こちらの Microsoft Learn のモジュール[GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) がおすすめです。
+なお、Microsoft Azure の Azure Container registry と Azure Web Apps を利用したデプロイを知りたい方は、こちらの Microsoft Learn のモジュール[GitHub Actions を使ったアプリケーションのビルドと Azure へのデプロイ](https://docs.microsoft.com/ja-jp/learn/modules/github-actions-cd/) がおすすめです。
 
 </p>
 </details>
@@ -36,4 +34,22 @@
 
 演習では、 GitHub Learning Lab の [GitHub Actions: Publish to GitHub Packages | GitHub Learning Lab](https://lab.github.com/githubtraining/github-actions:-publish-to-github-packages) を実施します。このコースには、下記の内容が含まれています。
 
-- 
+- ベースとなるワークフローのセットアップ（CI の処理が記載されている）
+- `docker/build-push-action` アクションを用いて、Docker コンテナイメージのビルドと push を行う
+- Personal access token を用いて、Container registry からイメージを取得し起動してみる
+
+GitHub Learning Lab で作成したコンテナイメージを起動できましたか？ ブラウザで `http://localhost:8080` にアクセスすると、ビルドしたアプリケーション Tic Tac Toe (三目並べ) で遊ぶことができます。
+
+さて、GitHub Learning Lab での演習が終わったら、Microsoft Learn に戻り「知識チェック」を済ませてモジュールを完了しましょう。
+
+## 備考
+
+### `docker/build-push-action` アクションについて
+
+`docker/build-push-action` は、 Docker イメージをビルドし指定したレジストリに push することができるアクションです。
+
+さまざまな機能が提供されており、柔軟なワークフローの実現をサポートします。詳しくは Marketplace や当該リポジトリをご参照ください。
+
+- [docker/build-push-action - Build and push Docker images · Actions · GitHub Marketplace](https://github.com/marketplace/actions/build-and-push-docker-images)
+
+なお、GitHub Learning Lab の演習では `v1` が利用されていましたが、現在は Docker [Buildx](https://github.com/docker/buildx) に対応した `v2` がリリースされており、こちらの利用が推奨されています。実際に使う際は、よくご確認の上ご利用ください。


### PR DESCRIPTION
掲題の対応について、ドキュメントを更新しました。

ドキュメント全体の確認は、[`add-how-to-deploy-container` ブランチ](https://github.com/zengeeks/devops-workshop-basic/tree/add-how-to-deploy-container) に切替えると見やすいです。

fixes #2