### PR TITLE
Update a link to the updated Japanese page

### DIFF
--- a/continuous-deployment/deploy-to-azure-web-app.md
+++ b/continuous-deployment/deploy-to-azure-web-app.md
@@ -8,8 +8,7 @@ Azure Web App は様々な言語に対応した PaaS サービスです。詳細
 
 ここでは、下記のドキュメントを参考に学習を進めます。
 
-- [Continuous deployment to Azure App Service](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment?tabs=github)
-  - ※ 日本語の記事の更新が追いついておらず GitHub Actions の記載がないため、英語のドキュメントを参照します。
+- [継続的なデプロイを構成する - Azure App Service | Microsoft Docs](https://docs.microsoft.com/ja-jp/azure/app-service/deploy-continuous-deployment?tabs=github)
 
 <details><summary>備考: Microsoft Learn の関連コンテンツ</summary>
 <p>


### PR DESCRIPTION
Azure App Service の継続的デリバリーに関するドキュメントの日本語版が更新されていたので、差し替えます。
- https://docs.microsoft.com/ja-jp/azure/app-service/deploy-continuous-deployment?tabs=github